### PR TITLE
buildAgent.properties must be writable.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,6 +8,7 @@ class teamcity_agent::config inherits teamcity_agent {
     replace => 'no',
     source  => 'puppet:///modules/teamcity_agent/buildAgent.properties',
     owner   => $user,
+    mode    => 0644
   }
 
   # Have the latest properties augeas lens available for configuring properties files


### PR DESCRIPTION
This module relies on the build agent setting the authorizationToken which requires writing out the properties file, however it's possible that this properties file is not writable by the agent user. Best to capture this requirement within the module itself.