### PR TITLE
Create directory buildAgent/logs.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,30 +1,45 @@
+#
 class teamcity_agent::config inherits teamcity_agent {
+
+  # TODO(tlimoncelli): store the port number in
+  # /home/${user}/buildAgent/logs/buildAgent.port
+  # so that /home/teamcity/buildAgent/bin/agent.sh works.
 
   $propfile = "/home/${user}/buildAgent/conf/buildAgent.properties"
 
   # Install the default unconfigured configuration file if missing
   file { $propfile:
-    ensure  => 'present',
+    ensure  => file,
+    owner   => $user,
+    group   => $group,
+    mode    => '0644',
     replace => 'no',
     source  => 'puppet:///modules/teamcity_agent/buildAgent.properties',
-    owner   => $user,
+    require => Class['teamcity_agent::install'],
   }
+  # FIXME(tlimoncelli): Consider creating $propfile file by copying
+  #   /home/teamcity/buildAgent/conf/buildAgent.dist.properties
 
   # Have the latest properties augeas lens available for configuring properties files
   $lens = '/usr/share/augeas/lenses/propertieslatest.aug'
   file { $lens:
     ensure => file,
+    owner  => $user,
+    group  => $group,
+    mode   => '0644',
     source => 'puppet:///modules/teamcity_agent/propertieslatest.aug',
   }
 
   augeas { $propfile:
-    lens    => "propertieslatest.lns",
+    lens    => 'propertieslatest.lns',
     incl    => $propfile,
     changes => [
       "set serverUrl ${server_url}",
       "set name ${agent_name}",
       "set ownAddress ${own_address}",
-      "set ownPort ${own_port}"
+      "set ownPort ${own_port}",
+      'set teamcity.git.use.local.mirrors true',
+      'set teamcity.git.use.shallow.clone true',
     ],
     require => [ File[$propfile], File[$lens] ],
   }
@@ -43,7 +58,7 @@ class teamcity_agent::config inherits teamcity_agent {
   }
 
   file { "/etc/init.d/${service}":
-    ensure  => 'present',
+    ensure  => file,
     content => template('teamcity_agent/init_script.erb'),
     mode    => '0755',
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,8 @@ class teamcity_agent(
   $wget        = $teamcity_agent::params::wget,
   $unzip       = $teamcity_agent::params::unzip,
 
+  $javapackage = $teamcity_agent::params::javapackage,
+
 ) inherits teamcity_agent::params {
 
   include '::teamcity_agent::requirements'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,4 +20,12 @@ class teamcity_agent::install inherits teamcity_agent {
   Exec[$download_command] ->
     Exec[$unzip_command]
 
+  file { "/home/${user}/buildAgent/logs":
+    ensure  => directory,
+    mode    => '0775',
+    owner   => $user,
+    group   => $user,
+    require => Exec[$unzip_command],
+  }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,15 +1,18 @@
 class teamcity_agent::params {
 
   $user        = 'teamcity'
+  $group       = 'teamcity'
   $service     = 'teamcity_agent'
 
   $server_url  = 'http://localhost/'
-  $agent_name  = $hostname
-  $own_address = 'localhost'
+  $agent_name  = $::hostname
+  $own_address = $::fqdn
   $own_port    = '9090'
   $properties  = { }
 
   $wget        = '/usr/bin/wget'
   $unzip       = '/usr/bin/unzip'
+
+  $javapackage = 'icedtea-6-jre-jamvm'
 
 }

--- a/manifests/requirements.pp
+++ b/manifests/requirements.pp
@@ -2,6 +2,6 @@ class teamcity_agent::requirements inherits teamcity_agent {
 
   if ! defined(Package['wget'])                { package { 'wget':                ensure => installed, } }
   if ! defined(Package['unzip'])               { package { 'unzip':               ensure => installed, } }
-  if ! defined(Package['icedtea-6-jre-jamvm']) { package { 'icedtea-6-jre-jamvm': ensure => installed, } }
+  if ! defined(Package[$javapackage])          { package { $javapackage:          ensure => installed, } }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,11 @@
+{
+  "author": "eirc",
+  "dependencies": [],
+  "description": "",
+  "license": "Apache License, Version 2.0",
+  "name": "eirc-teamcity_agent",
+  "project_page": "https://github.com/eirc/puppet-teamcity_agent",
+  "source": "https://github.com/eirc/puppet-teamcity_agent",
+  "summary": "Puppet module for installing a teamcity agent.",
+  "version": "0.2.0"
+}

--- a/templates/init_script.erb
+++ b/templates/init_script.erb
@@ -9,6 +9,16 @@
 # Description:       TeamCity Build Agent
 ### END INIT INFO
 
+if [[ -f /etc/redhat-release ]]; then
+  function status_of_proc() {
+    /home/teamcity/buildAgent/bin/agent.sh status
+  }
+  # TODO(tlim): Create a real "status" function.
+else
+  . /lib/init/vars.sh
+  . /lib/lsb/init-functions
+fi
+
 set -e
 
 PATH=/sbin:/bin:/usr/bin
@@ -16,9 +26,6 @@ USER=<%= @user %>
 SCRIPT=/home/<%= @user %>/buildAgent/bin/agent.sh
 NAME=<%= @service %>
 PIDFILE=/home/<%= @user %>/buildAgent/logs/buildAgent.pid
-
-. /lib/init/vars.sh
-. /lib/lsb/init-functions
 
 case "$1" in
     start)


### PR DESCRIPTION
The init.d script should work on CentOS too.
Parameterize own_address
Parameterize Java package name.
Every "file" resource should specify owner/groupo/mode.
"file" resource should ensure "file", not "present".
Fix dependencies.
Fix many lint issues (mostly wrong quotes being used).Set TeamCity
properties teamcity.git.use.local.mirrors and
teamcity.git.use.shallow.clone because disk space and bandwidth isn't
infinite.
Add TODO comments for needed features.